### PR TITLE
Update Minecraft Wiki links to new domain after fork

### DIFF
--- a/src/components/faq.js
+++ b/src/components/faq.js
@@ -150,7 +150,7 @@ function FAQ(props) {
       </p>
 
       <h2>Custom Blocks</h2>
-      <p>Custom blocks can be added from the bottom of the blocks selection pane. Different versions of a block can be added for the same block name, eg for 1.12.2 and 1.13.2+. Some examples are provided in the 'examples' section. NBT tags / block states can be found on the <a href="https://minecraft.fandom.com/wiki/Block_states" target="_blank" rel="noopener noreferrer">Minecraft Wiki</a>. To edit an existing custom block, select it, edit the tags / versions etc, and then click the 'add' button to overwrite. Note that presets URLs do not support custom blocks.</p>
+      <p>Custom blocks can be added from the bottom of the blocks selection pane. Different versions of a block can be added for the same block name, eg for 1.12.2 and 1.13.2+. Some examples are provided in the 'examples' section. NBT tags / block states can be found on the <a href="https://minecraft.wiki/w/Block_states" target="_blank" rel="noopener noreferrer">Minecraft Wiki</a>. To edit an existing custom block, select it, edit the tags / versions etc, and then click the 'add' button to overwrite. Note that presets URLs do not support custom blocks.</p>
 
       <div style={{ textAlign: "center" }}>
         <img alt="Palette" src={IMG_Palette} />

--- a/src/components/mapart/nbtReader.js
+++ b/src/components/mapart/nbtReader.js
@@ -1,7 +1,7 @@
 /*
   A mapping from type names to NBT type numbers.
   This is NOT just an enum, these values have to stay as they are
-  https://minecraft.fandom.com/wiki/NBT_format#TAG_definition
+  https://minecraft.wiki/w/NBT_format#TAG_definition
 */
 const TagTypes = {
   end: 0,

--- a/src/components/mapart/workers/nbt.jsworker
+++ b/src/components/mapart/workers/nbt.jsworker
@@ -18,7 +18,7 @@ var progressReportHead;
 /*
   A mapping from type names to NBT type numbers.
   This is NOT just an enum, these values have to stay as they are
-  https://minecraft.fandom.com/wiki/NBT_format#TAG_definition
+  https://minecraft.wiki/w/NBT_format#TAG_definition
 */
 const TagTypes = {
   end: 0,

--- a/tools/addColoursJSONColourSet.py
+++ b/tools/addColoursJSONColourSet.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     #     action = "store",
     #     type = int)
     parser.add_argument("mapdatId",
-        help = "Mojang-specified mapdatId (see https://minecraft.fandom.com/wiki/Map_item_format#Color_table)",
+        help = "Mojang-specified mapdatId (see https://minecraft.wiki/w/Map_item_format#Color_table)",
         metavar = "MAPDATID",
         action = "store",
         type = int)


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: <https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom>. This PR updates all the URLs to the new domain: minecraft.wiki