### PR TITLE
Fix syntax error in Spanish strings.json

### DIFF
--- a/src/locale/es/strings.json
+++ b/src/locale/es/strings.json
@@ -100,7 +100,7 @@
       "CLASSIC": "Encendido (clásico)",
       "VALLEY": "Encendido (valle)",
       "FULL-DARK": "Oscuro (Creciente Sur-Norte)",
-      "FULL-LIGHT": "Claro (Creciente Norte-Sur)",,
+      "FULL-LIGHT": "Claro (Creciente Norte-Sur)",
       "ON": "Encendido",
       "ON-UNOBTAINABLE": "Encendido (No obtenibles)",
       "FULL-UNOBTAINABLE": "Solo colores no obtenibles"


### PR DESCRIPTION
Removed an extra comma in the FULL-LIGHT string entry.